### PR TITLE
Streamline billing sidebar

### DIFF
--- a/billing/failed-payments.mdx
+++ b/billing/failed-payments.mdx
@@ -1,0 +1,22 @@
+---
+title: "Failed payments"
+description: "Troubleshoot invoices that can't be processed."
+---
+
+## Overview
+
+Use this page to describe what happens when a payment attempt fails and how customers can fix the issue.
+
+## Common causes
+
+- Expired or invalid payment method.
+- Insufficient funds.
+- Temporary bank restrictions or fraud checks.
+
+## Resolution steps
+
+1. Ask the customer to review and update their payment details.
+2. Retry the payment manually or wait for the automatic retry window.
+3. Escalate to your support or finance team if the issue persists.
+
+> ℹ️ **Note:** Document any automated emails or in-product notices that are sent after a failed payment.

--- a/billing/pausing-payments.mdx
+++ b/billing/pausing-payments.mdx
@@ -1,0 +1,16 @@
+---
+title: "Pausing payments"
+description: "How to temporarily stop billing without canceling your account."
+---
+
+## Overview
+
+Explain how customers can pause their billing cycle while keeping their account active. Update this section with the exact steps that apply to your product.
+
+## Steps to pause payments
+
+1. Navigate to your billing settings.
+2. Choose the option to pause or suspend payments.
+3. Confirm the duration of the pause and save your changes.
+
+> 💡 **Tip:** Clarify whether any features are limited while payments are paused.

--- a/docs.json
+++ b/docs.json
@@ -11,77 +11,18 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Guides",
+        "tab": "Main",
         "groups": [
           {
-            "group": "Getting started",
+            "group": "Billing",
             "pages": [
-              "index",
-              "quickstart",
-              "development"
-            ]
-          },
-          {
-            "group": "Customization",
-            "pages": [
-              "essentials/settings",
-              "essentials/navigation"
-            ]
-          },
-          {
-            "group": "Writing content",
-            "pages": [
-              "essentials/markdown",
-              "essentials/code",
-              "essentials/images",
-              "essentials/reusable-snippets"
-            ]
-          },
-          {
-            "group": "AI tools",
-            "pages": [
-              "ai-tools/cursor",
-              "ai-tools/claude-code",
-              "ai-tools/windsurf"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "API reference",
-        "groups": [
-          {
-            "group": "API documentation",
-            "pages": [
-              "api-reference/introduction"
-            ]
-          },
-          {
-            "group": "Endpoint examples",
-            "pages": [
-              "api-reference/endpoint/get",
-              "api-reference/endpoint/create",
-              "api-reference/endpoint/delete",
-              "api-reference/endpoint/webhook"
+              "billing/pausing-payments",
+              "billing/failed-payments"
             ]
           }
         ]
       }
-    ],
-    "global": {
-      "anchors": [
-        {
-          "anchor": "Documentation",
-          "href": "https://mintlify.com/docs",
-          "icon": "book-open-cover"
-        },
-        {
-          "anchor": "Blog",
-          "href": "https://mintlify.com/blog",
-          "icon": "newspaper"
-        }
-      ]
-    }
+    ]
   },
   "logo": {
     "light": "/logo/light.svg",
@@ -102,15 +43,15 @@
   },
   "contextual": {
     "options": [
-     "copy",
-     "view",
-     "chatgpt",
-     "claude",
-     "perplexity",
-     "mcp",
-     "cursor",
-     "vscode"
-   ]
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
   },
   "footer": {
     "socials": {


### PR DESCRIPTION
## Summary
- reduce the sidebar configuration to a single Billing group with two pages
- add stub Billing documentation pages for pausing and failed payments

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68d14417b4148325b08191e2bad935f5